### PR TITLE
Modifications to allow cmake-maven to function on ARM

### DIFF
--- a/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
+++ b/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
@@ -75,12 +75,20 @@ public class GetBinariesMojo
 	@SuppressWarnings("UWF_UNWRITTEN_FIELD")
 	@Parameter(property = "project", required = true, readonly = true)
 	private MavenProject project;
+        
+        @Parameter(property = "use.native.cmake", defaultValue = "false")
+        private boolean useNativeCmake;
 
 	@Override
 	@SuppressWarnings("NP_UNWRITTEN_FIELD")
 	public void execute()
 		throws MojoExecutionException
 	{
+                if (useNativeCmake){
+                    this.getLog().info("Configured to use native cmake, skipping download.");
+                    return;
+                } // Use native cmake
+                
 		String suffix;
 
 		if (classifier.equals("windows"))

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -4,9 +4,8 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.4.1-b1</version>
+		<version>3.4.1-b2-SNAPSHOT</version>
 	</parent>
-	<groupId>com.javatechnics</groupId>
 	<artifactId>cmake-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
 	<name>CMake Maven Plugin</name>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -4,8 +4,9 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.4.1-b2-SNAPSHOT</version>
+		<version>3.4.1-b1</version>
 	</parent>
+	<groupId>com.javatechnics</groupId>
 	<artifactId>cmake-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
 	<name>CMake Maven Plugin</name>
@@ -196,13 +197,13 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
+<!--		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>cmake-binaries</artifactId>
 			<version>${project.version}</version>
 			<classifier>${cmake.classifier}</classifier>
 			<scope>test</scope>
-		</dependency>
+		</dependency> -->
 	</dependencies>
 
 	<!-- Run tests from ${test-repo} repository instead of the local repo -->

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -4,9 +4,8 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.4.1-b1</version>
+		<version>3.4.1-b2-SNAPSHOT</version>
 	</parent>
-	<groupId>com.javatechnics</groupId>
 	<artifactId>cmake-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
 	<name>CMake Maven Plugin</name>
@@ -197,13 +196,13 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
-<!--		<dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>cmake-binaries</artifactId>
 			<version>${project.version}</version>
 			<classifier>${cmake.classifier}</classifier>
 			<scope>test</scope>
-		</dependency> -->
+		</dependency> 
 	</dependencies>
 
 	<!-- Run tests from ${test-repo} repository instead of the local repo -->

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
@@ -73,6 +73,15 @@ public class CompileMojo
 	@Parameter(property = "project", required = true, readonly = true)
 	private MavenProject project;
 
+        @Parameter(property = "use.native.cmake", defaultValue = "false")
+        private boolean useNativeCmake;
+        
+        @Parameter(property = "cmake.root.dir", defaultValue = "/usr", required = false)
+        private String cmakeRootDir;
+        
+        @Parameter(property = "cmake.child.dir", defaultValue = "bin/cmake", required = false)
+        private String cmakeChildDir;
+        
 	@Override
 	@SuppressWarnings("NP_UNWRITTEN_FIELD")
 	public void execute()
@@ -85,8 +94,10 @@ public class CompileMojo
 			if (!projectDirectory.isDirectory())
 				throw new MojoExecutionException(projectDirectory.getAbsolutePath() + " must be a directory");
 
-//			File cmakeFile = new File(project.getBuild().getDirectory(), "dependency/cmake/bin/cmake");
-			File cmakeFile = new File("/usr/bin/cmake");
+			File cmakeFile = useNativeCmake ? new File(cmakeRootDir + "/" + cmakeChildDir)
+                                : new File(project.getBuild().getDirectory(), "dependency/cmake/bin/cmake");
+                        if (useNativeCmake) getLog().info("Configured to use native CMake.");
+                        
 			ProcessBuilder processBuilder = new ProcessBuilder(cmakeFile.getAbsolutePath(),
 				"--build", projectDirectory.getPath());
 			if (target != null)

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
@@ -85,7 +85,8 @@ public class CompileMojo
 			if (!projectDirectory.isDirectory())
 				throw new MojoExecutionException(projectDirectory.getAbsolutePath() + " must be a directory");
 
-			File cmakeFile = new File(project.getBuild().getDirectory(), "dependency/cmake/bin/cmake");
+//			File cmakeFile = new File(project.getBuild().getDirectory(), "dependency/cmake/bin/cmake");
+			File cmakeFile = new File("/usr/bin/cmake");
 			ProcessBuilder processBuilder = new ProcessBuilder(cmakeFile.getAbsolutePath(),
 				"--build", projectDirectory.getPath());
 			if (target != null)

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
@@ -117,7 +117,7 @@ public class GenerateMojo
 				else if (os.toLowerCase().startsWith("linux"))
 					if (arch.equals("x86_64") || arch.equals("amd64"))
 						classifier = "linux64";
-					else if (arch.equals("i386"))
+					else if (arch.equals("i386") || arch.equals("arm"))
 						classifier = "linux32";
 					else throw new MojoExecutionException("Unsupported Linux arch: " + arch);
 				else if (os.toLowerCase().startsWith("mac"))
@@ -127,7 +127,8 @@ public class GenerateMojo
 				else
 					throw new MojoExecutionException("Unsupported os.name: " + os);
 			}
-			File cmakeDir = new File(project.getBuild().getDirectory(), "dependency/cmake");
+//			File cmakeDir = new File(project.getBuild().getDirectory(), "dependency/cmake");
+			File cmakeDir = new File("/usr");
 			String binariesArtifact = "cmake-binaries";
 
 			Element groupIdElement = new Element("groupId", groupId);
@@ -139,12 +140,12 @@ public class GenerateMojo
 				versionElement, classifierElement, outputDirectoryElement);
 			Element artifactItemsItem = new Element("artifactItems", artifactItemElement);
 			Xpp3Dom configuration = MojoExecutor.configuration(artifactItemsItem);
-			ExecutionEnvironment environment = MojoExecutor.executionEnvironment(project, session,
+/*			ExecutionEnvironment environment = MojoExecutor.executionEnvironment(project, session,
 				pluginManager);
 			Plugin dependencyPlugin = MojoExecutor.plugin("org.apache.maven.plugins",
 				"maven-dependency-plugin", "2.8");
 			MojoExecutor.executeMojo(dependencyPlugin, "unpack", configuration, environment);
-
+*/
 			ProcessBuilder processBuilder = new ProcessBuilder(new File(cmakeDir, "bin/cmake").getAbsolutePath(),
 				"-G", generator).directory(targetPath);
 			if (options != null)

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/TestMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/TestMojo.java
@@ -15,40 +15,31 @@ package com.googlecode.cmakemavenproject;
  * the License.
  */
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.BufferedReader;
 import java.io.InputStreamReader;
-
 import java.nio.charset.Charset;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
 import org.apache.maven.project.MavenProject;
-
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 /**
  * Goal which runs CMake/CTest tests.
@@ -105,6 +96,19 @@ public class TestMojo extends AbstractMojo
 	 */
 	@Parameter
 	private List<String> options;
+        
+        @Parameter(property = "use.native.cmake", defaultValue = "false")
+        private boolean useNativeCmake;
+        
+        @Parameter(property = "cmake.root.dir", defaultValue = "/usr", required = false)
+        private String cmakeRootDir;
+        
+        @Parameter(property = "cmake.child.dir", defaultValue = "bin/cmake", required = false)
+        private String cmakeChildDir;
+        
+        @Parameter(property = "cmake.ctest.dir", defaultValue = "/", required = false)
+        private String ctestChildDir;
+        
 	/**
 	 * Executes the CTest run.
 	 */
@@ -135,9 +139,19 @@ public class TestMojo extends AbstractMojo
 			if (!buildDirectory.isDirectory())
 				throw new MojoExecutionException(buildDir + " isn't directory");
 
-			path = new File(projBuildDir, "dependency/cmake").getAbsoluteFile();
-			args = new ArrayList<String>(Arrays.asList(new File(path, "bin/ctest")
+                        if (useNativeCmake){
+                            path = new File(cmakeRootDir, cmakeChildDir).getAbsoluteFile();
+                            args = new ArrayList<String>(Arrays.asList(
+                                new File(new File(cmakeRootDir, ctestChildDir).getAbsoluteFile(), "bin/ctest")
 				.getAbsolutePath(), "-T", "Test", "-j", threadCountString));
+                        }else{
+                            path = new File(projBuildDir, "dependency/cmake").getAbsoluteFile();
+                            args = new ArrayList<String>(Arrays.asList(
+                                new File(new File(projBuildDir, "dependency/cmake").getAbsoluteFile(), "bin/ctest")
+				.getAbsolutePath(), "-T", "Test", "-j", threadCountString));
+                        }
+			
+			
 
 			// If set, this will post results to a pre-configured dashboard
 			if (dashboard != null) args.addAll(Arrays.asList("-D", dashboard));

--- a/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
+++ b/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
@@ -16,12 +16,9 @@ package com.googlecode.cmakemavenproject;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.util.Properties;
-
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
-
 import org.apache.maven.it.util.ResourceExtractor;
 
 /**
@@ -41,6 +38,8 @@ public abstract class CMakeMojoIntegrationTest
 
     // Get the classifier configured by our build process
     private static final String CMAKE_CLASSIFIER = "cmake.classifier";
+    
+    private static final String CMAKE_NATIVE = "use.native.cmake";
 
     /**
      * Returns a <code>Verifier</code> that has been configured to use the test
@@ -68,7 +67,11 @@ public abstract class CMakeMojoIntegrationTest
 
         // We need to pass along the version number of our parent project
         sysProperties.setProperty(CMP_VERSION, System.getProperty(CMP_VERSION));
-
+        
+        if (System.getProperty(CMAKE_NATIVE) != null 
+                && System.getProperty(CMAKE_NATIVE).equals("true")){
+            sysProperties.setProperty(CMAKE_NATIVE, "true");
+        }
         // Set the profile that's being used in the running of the tests
         verifier.addCliOption(getActivatedProfile());
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.googlecode.cmake-maven-project</groupId>
 	<artifactId>cmake</artifactId>
-	<version>3.4.1-b1</version>
+	<version>3.4.1-b2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>CMake</name>
 	<description>Builds native code using CMake makefile generator</description>
@@ -102,8 +102,8 @@
 		</pluginManagement>
 	</build>
 	<modules>
-<!--		<module>cmake-binaries-plugin</module> -->
-<!--		<module>cmake-binaries</module> -->
+		<module>cmake-binaries-plugin</module> 
+		<module>cmake-binaries</module> 
 		<module>cmake-maven-plugin</module>
 	</modules>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.googlecode.cmake-maven-project</groupId>
 	<artifactId>cmake</artifactId>
-	<version>3.4.1-b2-SNAPSHOT</version>
+	<version>3.4.1-b1</version>
 	<packaging>pom</packaging>
 	<name>CMake</name>
 	<description>Builds native code using CMake makefile generator</description>
@@ -102,8 +102,8 @@
 		</pluginManagement>
 	</build>
 	<modules>
-		<module>cmake-binaries-plugin</module>
-		<module>cmake-binaries</module>
+<!--		<module>cmake-binaries-plugin</module> -->
+<!--		<module>cmake-binaries</module> -->
 		<module>cmake-maven-plugin</module>
 	</modules>
 	<properties>


### PR DESCRIPTION
This set of changes I introduced to allow the plugin to be both built and used on ARM architecture, more specifically the RaspberryPi.
The modifications make use of the native CMake which can easily be installed on the RaspberryPi or any Linux device via the package manager. This is necessary on the Pi as there is no binary which can be downloaded for ARM at plugin execution time. The changes introduced have the added benefit that native CMake can be used on x86 or amd64 Linux architecture.
The additional functionality introduced here is enabled through the use of command line flags to Maven:

-Duse.native.cmake

-Dcmake.root.dir

-Dcmake.child.dir

-Dcmake.ctest.dir

The most important of these and the one that in general only needs to be set to 'true' is '-Duse.native.cmake', thus the changes introduced are inactive by default. The others allow to specify the location of CMake and Ctest should they differ from the defaults in the plugin. 'use.native.cmake' can be used when building the plugin itself or when building a project that uses the plugin.

One final point is that 64-bit ARM architecture is unlikely to work with the plugin currently. I hope to remedy this once I can obtain the latest Pi.
